### PR TITLE
RadioButton&handlingInvisbleElements

### DIFF
--- a/cypress/integration/examples/WebUI.js
+++ b/cypress/integration/examples/WebUI.js
@@ -28,7 +28,22 @@ describe('WebTest Suite', function () {
 
           cy.get('input#autocomplete').should('have.value','India')
 
+        //Handle Invisble Elements & Assertions
+          cy.get('input#displayed-text').should('be.visible')
+          cy.get('input#hide-textbox').click()
+          cy.get('input#displayed-text').should('not.be.visible')
+          cy.get('input#show-textbox').click()
+          cy.get('input#displayed-text').should('be.visible')
 
+
+        //Radio Buttons
+        cy.get('input[value="radio1"]').click().should('be.checked')
+        //Clicking all the Options of Radio Buttons
+        /*cy.get('input[name="radioButton"]').each(($el, index, $list) => {
+             cy.wrap($el).click()
+            
+          })
+          */
     }
 )
 


### PR DESCRIPTION
Code for Handling Radio Buttons & Invisible Elements


Here's the code for handling radio buttons and invisible elements in Cypress.  The code uses the 'should' statement to assert that the invisible element is visible, and the radio button is checked.

Here is the code for handling radio buttons and invisible elements in Cypress. The code utilizes the "should" statement to assert that the invisible element is visible and that the radio button is selected.